### PR TITLE
chore(cli): clean a bit `get_page_annoatations_mut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,8 +495,7 @@ dependencies = [
 [[package]]
 name = "lopdf"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab029c5cd5b0a292b05e3121b6bcf02f20e58e85ffe6d5417a38c1f8f24cbf7"
+source = "git+https://github.com/J-F-Liu/lopdf.git?rev=c919839#c919839096ba67d9d3d87b26650419016be5c631"
 dependencies = [
  "chrono",
  "encoding_rs",
@@ -504,11 +503,18 @@ dependencies = [
  "itoa",
  "linked-hash-map",
  "log",
+ "md5",
  "nom",
  "rayon",
  "time",
  "weezl",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ anyhow = "1.0.71"
 clap = {version = "4.2.5", features = ["derive", "wrap_help", "env"]}
 clap_complete = "4.2.1"
 is-terminal = "0.4.7"
-lopdf = "0.30.0"
+lopdf = { git = "https://github.com/J-F-Liu/lopdf.git", rev = "c919839" }
 owo-colors = "3.5.0"
 tabled = {version = "0.12.0", features = ["color"]}
 termcolor = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 > PDF command-line utils written in Rust.
 
-*rpdf makes working with PDF annotions super easy! It can `merge` annotations from multiple files,
+*rpdf makes working with PDF annotions super easy!
+It can `merge` annotations from multiple files,
 some show statistics (`stats`) or `strip` specific (or all) annotations.*
 
 [![Crates.io](https://img.shields.io/crates/v/rpdf)](https://crates.io/crates/rpdf)
@@ -13,11 +14,13 @@ some show statistics (`stats`) or `strip` specific (or all) annotations.*
 
 ## About
 
-rpdf is a Rust binary that aims to provides an open source and straighforward command-line alternative to other
-tools such as [PDF Annotator](https://www.pdfannotator.com/en/help/filescombine) and others.
+rpdf is a Rust binary that aims to provides an open source and straighforward
+command-line alternative to other tools such as
+[PDF Annotator](https://www.pdfannotator.com/en/help/filescombine) and others.
 
-*Disclaimer: rpdf is currently in an early stage, and does not implement many features.
-I was first developed for my own use, because I needed to merge annotations from PDFs I review with other people.
+*Disclaimer: rpdf is currently in an early stage, and does not implement many
+features. I was first developed for my own use,
+because I needed to merge annotations from PDFs I review with other people.
 Do not hesitate to propose new features if you feel they could be intersting!*
 
 ## Installation
@@ -34,7 +37,8 @@ The command line tool is pretty straighforward to use and is self-documented:
 
 ![CLI](https://user-images.githubusercontent.com/27275099/235343778-01eceb0a-e138-4dbc-be0c-824a4ae01f06.png)
 
-Anytime you need help for a command, you can use `rpdf <COMMAND> --help`, or `-h` for the short version.
+Anytime you need help for a command, you can use `rpdf <COMMAND> --help`,
+or `-h` for the short version.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ and verify that all the annotations are present in the final product:
 
 #### Strip annotations
 
-If you want to remove some annotations from a PDF, you can do so with the `strip` command:
+If you want to remove some annotations from a PDF,
+you can do so with the `strip` command:
 
 ![strip](https://user-images.githubusercontent.com/27275099/235351437-5846c8bf-cd1c-4f27-9f3a-04257251251b.png)
 


### PR DESCRIPTION
A bit of cleaning using the new `as_hashmap_*` functions from `lopdf`.
